### PR TITLE
feat(api): created function to duplicate introductions

### DIFF
--- a/app/controllers/api/professors/introductions_controller.rb
+++ b/app/controllers/api/professors/introductions_controller.rb
@@ -43,6 +43,20 @@ class Api::Professors::IntroductionsController < ApplicationController
     render json: { message: feminine_unsuccess_destroy_message }, status: :unprocessable_entity
   end
 
+  def duplicate
+    duplicated_introduction = @introduction.duplicate
+
+    if duplicated_introduction.save
+      render json: {
+        message: 'Introdução duplicada com sucesso', introduction: duplicated_introduction
+      }, status: :created
+    else
+      render json: {
+        message: 'Erro ao duplicar a introdução', errors: duplicated_introduction.errors
+      }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def introduction_params

--- a/app/models/introduction.rb
+++ b/app/models/introduction.rb
@@ -7,6 +7,28 @@ class Introduction < ApplicationRecord
 
   before_create :set_position
 
+  def duplicate
+    duplicated_introduction = dup
+
+    duplicated_introduction.description = description
+    duplicated_introduction.public = public
+    duplicated_introduction.position = position
+    duplicated_introduction.title = generate_duplicated_title
+    duplicated_introduction
+  end
+
+  def generate_duplicated_title
+    copy_number = 1
+    new_title = "#{title} (cópia - #{copy_number})"
+
+    while Introduction.exists?(title: new_title)
+      copy_number += 1
+      new_title = "#{title} (cópia - #{copy_number})"
+    end
+
+    new_title
+  end
+
   private
 
   def set_position

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
     namespace :api do
       namespace :professors do
         resources :los do
-          resources :introductions
+          resources :introductions do
+            post 'duplicate', on: :member
+          end
           resources :exercises do
             post 'duplicate', on: :member
             resources :solution_steps do

--- a/test/controllers/api/professors/introductions/duplicate_test.rb
+++ b/test/controllers/api/professors/introductions/duplicate_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Api::Professors::IntroductionsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @user = FactoryBot.create(:user)
+    sign_in @user
+
+    @lo = FactoryBot.create(:lo)
+    @introduction = FactoryBot.create(:introduction, lo: @lo)
+  end
+
+  test 'should successfully duplicate an introduction' do
+    post duplicate_api_professors_lo_introduction_path(@lo, @introduction), as: :json
+
+    assert_response :created
+    assert_equal RESPONSE::Type::JSON, response.content_type
+    data = response.parsed_body
+
+    assert_equal 'Introdução duplicada com sucesso', data['message']
+  end
+
+  test 'should fail to duplicate an exercise with non-existing ID' do
+    assert_raises(ActiveRecord::RecordNotFound) do
+      post duplicate_api_professors_lo_introduction_path(@lo, -1), as: :json
+    end
+  end
+end

--- a/test/models/introduction_test.rb
+++ b/test/models/introduction_test.rb
@@ -14,4 +14,27 @@ class IntroductionTest < ActiveSupport::TestCase
   context 'relationships' do
     should belong_to(:lo)
   end
+
+  context 'duplicating an introduction' do
+    setup do
+      @lo = FactoryBot.create(:lo)
+      @introduction = FactoryBot.create(:introduction, lo: @lo, title: 'Original Introduction', public: true)
+    end
+
+    should 'create a new introduction with a modified title' do
+      duplicated_introduction = @introduction.duplicate
+      duplicated_introduction.save
+
+      assert_not_nil duplicated_introduction
+      assert_match(/Original Introduction \(cópia - \d+\)/, duplicated_introduction.title)
+    end
+
+    should 'duplicate with the same description, public status, and position' do
+      duplicated_introduction = @introduction.duplicate
+
+      assert_equal @introduction.description, duplicated_introduction.description
+      assert_equal @introduction.public, duplicated_introduction.public
+      assert_equal @introduction.position, duplicated_introduction.position
+    end
+  end
 end


### PR DESCRIPTION
## PR Template

Issue: #**36**

### Description

New function created to duplicate introductions

### Motivation and Context

Allow the user to be able to duplicate a introductions

### How has this been tested?

This task was tested with the created unit tests and manually

### Screenshots (if appropriate):

### Types of changes

- [ ] fix: A bug fix
- [X] feat: A new feature
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] test: Adding missing tests or correcting existing tests
- [ ] perf: A code change that improves performance
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (e.g. prettier format)
- [ ] ci: Changes to our CI configuration files and scripts
- [ ] chore: Changes to the build process or auxiliary tools and librariesfunctionality to not work as expected)

### Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Hours Required:
