### PR TITLE
Remove node from Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -85,6 +85,7 @@ RUN apt-get update -qq && \
   cron         \
   sudo         \
   vim          \
+  watchman     \
   && rm -rf /var/lib/apt/lists/*
 
 ENV _USER rails

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -85,37 +85,7 @@ RUN apt-get update -qq && \
   cron         \
   sudo         \
   vim          \
-  && rm -rf /var/lib/apt/lists/*  
-
-# --------------------------
-# INSTALL NODEJS BY NVM and TAILWINDCSS CLI
-# This was necessary because tailwindcss standalone
-# does not work with docker image 
-# --------------------------
-ARG NODE_VERSION=22.14.0
-ARG NVM_DIR=/usr/local/nvm
-
-# https://github.com/creationix/nvm#install-script
-RUN mkdir $NVM_DIR && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
-
-# Add node and npm to path so the commands are available
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-
-# confirm installation
-RUN node -v
-RUN npm -v
-
-# Install global npm packages
-RUN npm install -g npm@11.2.0 && \
-  npm install -g @tailwindcss/cli
-
-# Set Tailwind CSS install directory
-ENV TAILWINDCSS_INSTALL_DIR=$NVM_DIR/versions/node/v$NODE_VERSION/bin
-
-# --------------------------
-# end of nodejs and tailwindcss installation
-# --------------------------
+  && rm -rf /var/lib/apt/lists/*
 
 ENV _USER rails
 ENV APP_NAME farma
@@ -148,12 +118,6 @@ USER ${_USER}:${_USER}
 WORKDIR $APP
 
 # Install bundler and rails
-RUN gem update --system 3.6.6 \ 
+RUN gem update --system 3.6.6 \
   && gem install bundler -v 2.6.6 \
   && gem install rails -v 8.0.2
-
-# Install TailwindCSS
-RUN npm install -D tailwindcss \
-  && npm install -D @tailwindcss/forms \
-  && npm install -D @tailwindcss/aspect-ratio \
-  && npm install -D  @tailwindcss/typography

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ x-app: &app
     - .:/var/www/farma
     - bundle_path:/bundle
     - /dev/shm:/dev/shm
-  tmpfs:
-    - /tmp
   depends_on:
     - db
   networks:

--- a/run
+++ b/run
@@ -60,6 +60,10 @@ function rails {
   dc rails "${@}"
 }
 
+function tailwind:watch {
+  dc rails tailwindcss:watch "${@}"
+}
+
 function rubocop {
   dc bundle exec rubocop --parallel "${@}"
 }


### PR DESCRIPTION
# Problem with `tmpfs` and TailwindCSS CLI > 4

The TailwindCSS CLI (version 4 and above) fails to run inside the container due to an option set in the `docker-compose.yml` file:

```yaml
tmpfs:
  - /tmp
```

## Why this happens
Mounting `/tmp` as `tmpfs` places it entirely in RAM. While this is usually fine — and can even improve performance — it causes issues when native modules (such as .node files) are:

Extracted into `/tmp`, and

Dynamically loaded via `dlopen()`

The `dlopen()` system call can't always map shared object files from memory-only file systems like tmpfs, especially in containerized environments with extra restrictions (like seccomp, AppArmor, or read-only mounts).

As a result, you might see an error like:
```
vbnet
Copy
Edit
failed to map segment from shared object
code: "ERR_DLOPEN_FAILED"
Solution
Simply removing the tmpfs mount for /tmp resolves the issue, allowing TailwindCSS CLI v4+ (e.g., when used via tailwindcss-rails) to work as expected.
```

## Solution
Simply removing the `tmpfs` mount for `/tmp` resolves the issue, allowing TailwindCSS CLI v4+ (e.g., when used via tailwindcss-rails) to work as expected.

---
Hours Required: 3